### PR TITLE
error: Handle error message from contexte when stringified

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,22 @@ export class N9Error extends Error {
 
 	constructor(message: string, status?: number, context?: any) {
 		super(message)
+
+		// we check if an error has been passed in the context
+		// if so we create an intermediary object
+		// to allow JSON.stringify to work correctly render the error's message
+		if (context) {
+			for (const key of Object.keys(context)) {
+				if (context[key] instanceof Error) {
+					context[key] = {
+						...context[key],
+						message: context[key].message,
+						name: context[key].name
+					}
+				}
+			}
+		}
+
 		this.message = message
 		this.status = status || 500
 		this.context = context || {}

--- a/test/n9-error.test.ts
+++ b/test/n9-error.test.ts
@@ -23,3 +23,23 @@ test('Should throw an error (context)', (t) => {
 	t.is(err.status, 505)
 	t.deepEqual(err.context, { test: true })
 })
+
+test('Should render the content of an error in the context when stringified', (t) => {
+	const error: any = new Error('This is an generic JS error')
+	error.status = 'this is a status'
+	error.name = 'errors name'
+	const n9err = new N9Error('error rendering', 500, { error })
+
+	const expected = JSON.stringify({
+		status: 500,
+		context: {
+			error: {
+				status: 'this is a status',
+				name: 'errors name',
+				message: 'This is an generic JS error',
+			}
+		}
+	})
+
+	t.is(JSON.stringify(n9err), expected)
+})


### PR DESCRIPTION
Currently, if you add an instance of Error in the context and use JSON.stringify() on the N9Error the message of the original error will not be displayed (some inheritance stuff that I don't really understand).

If an instance of Error is added to the context, then we create an intermediate object will all properties of the error to correct the behavior of JSON.stringify 